### PR TITLE
The great refactoring of Recycle Bin renamer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ CC=gcc
 all: trashbin.exe
 
 trashbin.exe: main.o resource.res
-	$(CC) -o $@ main.o resource.res
+	$(CC) -o $@ main.o resource.res -mwindows -municode
 
 .c.o:
-	$(CC) -o $@ -c $<
+	$(CC) -DUNICODE -D_UNICODE -o $@ -c $<
 
 .rc.res:
 	$(WINDRES) -O coff -o $@ $<

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: all clean
 .SUFFIXES:
 .SUFFIXES: .c .rc .o .res
 
@@ -15,3 +16,5 @@ trashbin.exe: main.o resource.res
 .rc.res:
 	$(WINDRES) -O coff -o $@ $<
 
+clean:
+	-rm -f *.o *.res *.exe

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
-all:
-	windres icon.rc -O coff -o icon.res
-	gcc main.c icon.res -o trashbin
+.SUFFIXES:
+.SUFFIXES: .c .rc .o .res
+
+WINDRES=windres
+CC=gcc
+
+all: trashbin.exe
+
+trashbin.exe: main.o resource.res
+	$(CC) -o $@ main.o resource.res
+
+.c.o:
+	$(CC) -o $@ -c $<
+
+.rc.res:
+	$(WINDRES) -O coff -o $@ $<
+

--- a/icon.rc
+++ b/icon.rc
@@ -1,2 +1,0 @@
-1 ICON "exeicon.ico"
-2 ICON "replacementicon.ico"

--- a/main.c
+++ b/main.c
@@ -3,7 +3,27 @@
 #include <string.h>
 #include <stdio.h>
 
-int main(int argc, char* argv[]){
+#include "resource.h"
+
+char startup_path[MAX_PATH];
+char filename[MAX_PATH];
+
+void rename_trash(void);
+void get_startup_path(void);
+void copy_to_startup(void);
+void swap_icon(void);
+
+int main(int argc, char* argv[]) {
+    rename_trash();
+    get_startup_path();
+    copy_to_startup();
+    swap_icon();
+
+    return 0;
+}
+
+void rename_trash(void)
+{
     HKEY recycleBinHKey;
     LPCSTR registrySubkey = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\CLSID\\{645FF040-5081-101B-9F08-00AA002F954E}";
     const BYTE * pnewValue = (const BYTE *) "SIBADI";
@@ -11,28 +31,47 @@ int main(int argc, char* argv[]){
     RegSetValueExA(recycleBinHKey, NULL, 0, REG_SZ, pnewValue, strlen(pnewValue));
     SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_FLUSHNOWAIT, NULL, NULL);
     RegCloseKey(recycleBinHKey);
+}
 
-    const char* command[345];
-    char filename[MAX_PATH];
+void get_startup_path(void)
+{
+    char *exename;
+
     GetModuleFileName(NULL, filename, MAX_PATH);
-    char* exename = strrchr(filename, '\\');
+    exename = strrchr(filename, '\\');
+
     if (exename != NULL) {
         exename++;
     } else {
         exename = filename;
     }
 
-    sprintf(command, "copy \"%s\" \"%%USERPROFILE%%\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\"", exename);
+    sprintf(startup_path, "%%USERPROFILE%%\\"
+            "AppData\\Roaming\\"
+            "Microsoft\\Windows\\"
+            "Start Menu\\Programs\\Startup\\%s",
+            exename);
+}
+
+void copy_to_startup(void)
+{
+    char command[345];
+
+    sprintf(command, "copy \"%s\" \"%s\"", filename, startup_path);
     system(command);
+}
+
+void swap_icon(void)
+{
     LPCSTR iconRegistryKey = "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\CLSID\\{645FF040-5081-101B-9F08-00AA002F954E}\\DefaultIcon";
-    const char* iconPath[256];
+    char iconPath[256];
     HKEY recycleBinIconHKey;
-    sprintf(iconPath, "%%USERPROFILE%%\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\%s,-2", exename);
+
+    sprintf(iconPath, "%s,-%d", startup_path, IDI_REPLACEMENT);
     RegOpenKeyExA(HKEY_CURRENT_USER, iconRegistryKey, 0, KEY_SET_VALUE, &recycleBinIconHKey);
     RegSetValueExA(recycleBinIconHKey, "full", 0, REG_EXPAND_SZ, (const BYTE*)iconPath, strlen(iconPath));
     RegSetValueExA(recycleBinIconHKey, "empty", 0, REG_EXPAND_SZ, (const BYTE*)iconPath, strlen(iconPath));
     RegSetValueExA(recycleBinIconHKey, NULL, 0, REG_EXPAND_SZ, (const BYTE*)iconPath, strlen(iconPath));
     RegCloseKey(recycleBinIconHKey);
     SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_FLUSHNOWAIT, NULL, NULL);
-    return 0;
 }

--- a/main.c
+++ b/main.c
@@ -21,7 +21,13 @@ void get_startup_path(void);
 void copy_to_startup(void);
 void swap_icon(void);
 
-int main(int argc, char* argv[]) {
+INT WINAPI wWinMain(
+        HINSTANCE hThisInstance,
+        HINSTANCE hPrevInstance,
+        LPWSTR szCmdLine,
+        INT nCmdShow
+)
+{
     rename_trash();
     get_startup_path();
     copy_to_startup();

--- a/resource.h
+++ b/resource.h
@@ -1,0 +1,2 @@
+#define IDI_EXE         1
+#define IDI_REPLACEMENT 2

--- a/resource.rc
+++ b/resource.rc
@@ -1,0 +1,4 @@
+#include "resource.h"
+
+IDI_EXE         ICON "exeicon.ico"
+IDI_REPLACEMENT ICON "replacementicon.ico"


### PR DESCRIPTION
Short summary of changes:

- Magic numbers, redundant literals and computations has been eliminated
- Code has been split by shorter functions
- Narrow API has been fully replaced with wide API to support Unicode names (including cyrillic)
- Makefile has been fully rewritten
- Call of `copy` command has been replaced by WinAPI function `CopyFile` call

